### PR TITLE
Adapted file upload for Plack environment (was not working since 0.20)

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -10,6 +10,7 @@ my $builder = Module::Build->new(
     requires => {
       'AppConfig'           => 0,
       'File::Basename'      => 0,
+      'File::Copy'          => 0,
       'File::Path'          => 0,
       'File::Tabular'       => 0.71,
       'List::MoreUtils'     => 0,


### PR DESCRIPTION
L'upload de fichier ne fonctionnait plus depuis le passage à Plack, j'ai adapté Attachments.pm pour utiliser Plack::Request::Upload, les adaptations ont été testées en environnement mod_perl & plackup.

File::Copy a été utilisé à la place de "rename" lors du déplacement du fichier téléchargé pour éviter des problèmes de "invalid cross-device link" dans mon environnement de test.
